### PR TITLE
Add maintenance job to the DB consumer collection

### DIFF
--- a/config/builder_test.go
+++ b/config/builder_test.go
@@ -68,6 +68,7 @@ func TestBuilder_Config(t *testing.T) {
 				},
 			},
 		},
+		MaintenanceInterval: time.Hour * 1,
 	}
 
 	c, err := NewBuilder().SetTopicNameDecorator(dummyGenerator).Config()

--- a/config/config.go
+++ b/config/config.go
@@ -9,18 +9,19 @@ import (
 )
 
 const (
-	EnvVarHost           = "KAFKA_HOST"
-	EnvVarGroup          = "KAFKA_GROUP"
-	EnvVarSourceTopics   = "KAFKA_SOURCE_TOPICS"
-	EnvVarRetryIntervals = "KAFKA_RETRY_INTERVALS"
-	EnvVarTLSEnable      = "TLS_ENABLE"
-	EnvVarTLSSkipVerify  = "TLS_SKIP_VERIFY_PEER"
-	EnvVarDbRetryQueue   = "USE_DB_RETRY_QUEUE"
-	EnvVarDbHost         = "DB_HOST"
-	EnvVarDbPort         = "DB_PORT"
-	EnvVarDbPass         = "DB_PASS"
-	EnvVarDbUser         = "DB_USER"
-	EnvVarDbSchema       = "DB_SCHEMA"
+	EnvVarHost                  = "KAFKA_HOST"
+	EnvVarGroup                 = "KAFKA_GROUP"
+	EnvVarSourceTopics          = "KAFKA_SOURCE_TOPICS"
+	EnvVarRetryIntervals        = "KAFKA_RETRY_INTERVALS"
+	EnvVarTLSEnable             = "TLS_ENABLE"
+	EnvVarTLSSkipVerify         = "TLS_SKIP_VERIFY_PEER"
+	EnvVarDbRetryQueue          = "USE_DB_RETRY_QUEUE"
+	EnvVarDbMaintenanceInterval = "MAINTENANCE_INTERVAL_SECONDS"
+	EnvVarDbHost                = "DB_HOST"
+	EnvVarDbPort                = "DB_PORT"
+	EnvVarDbPass                = "DB_PASS"
+	EnvVarDbUser                = "DB_USER"
+	EnvVarDbSchema              = "DB_SCHEMA"
 )
 
 type Config struct {
@@ -29,12 +30,13 @@ type Config struct {
 	ConsumableTopics []*KafkaTopic
 	TopicMap         map[TopicKey]*KafkaTopic
 	// DBRetries is indexed by the topic name, and represents retry intervals for processing retries in the DB
-	DBRetries          DBRetries
-	TLSEnable          bool
-	TLSSkipVerifyPeer  bool
-	DB                 Database
-	UseDBForRetryQueue bool
-	topicNameGenerator topicNameGenerator
+	DBRetries             DBRetries
+	TLSEnable             bool
+	TLSSkipVerifyPeer     bool
+	DB                    Database
+	UseDBForRetryQueue  bool
+	MaintenanceInterval time.Duration
+	topicNameGenerator  topicNameGenerator
 }
 
 type KafkaTopic struct {
@@ -183,6 +185,7 @@ func (cfg *Config) loadFromEnvVars() error {
 	cfg.DB.Pass = os.Getenv(EnvVarDbPass)
 	cfg.DB.Schema = os.Getenv(EnvVarDbSchema)
 	cfg.DB.Port = envVarAsInt(EnvVarDbPort)
+	cfg.MaintenanceInterval = time.Second * time.Duration(envVarAsInt(EnvVarDbMaintenanceInterval))
 
 	sourceTopics := strings.Split(os.Getenv(EnvVarSourceTopics), ",")
 	retryIntervals, err := envVarAsIntSlice(EnvVarRetryIntervals)

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,10 @@ const (
 	EnvVarDbSchema              = "DB_SCHEMA"
 )
 
+var (
+	defaultMaintenanceInterval = time.Hour * 1
+)
+
 type Config struct {
 	Host             []string
 	Group            string
@@ -207,6 +211,10 @@ func (cfg *Config) loadFromEnvVars() error {
 
 	if err := cfg.addTopicsFromSource(sourceTopics, retryIntervals); err != nil {
 		return fmt.Errorf("consumer/config: error loading config with topic names from env vars: %w", err)
+	}
+
+	if cfg.MaintenanceInterval == 0 {
+		cfg.MaintenanceInterval = defaultMaintenanceInterval
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -30,10 +30,10 @@ type Config struct {
 	ConsumableTopics []*KafkaTopic
 	TopicMap         map[TopicKey]*KafkaTopic
 	// DBRetries is indexed by the topic name, and represents retry intervals for processing retries in the DB
-	DBRetries             DBRetries
-	TLSEnable             bool
-	TLSSkipVerifyPeer     bool
-	DB                    Database
+	DBRetries           DBRetries
+	TLSEnable           bool
+	TLSSkipVerifyPeer   bool
+	DB                  Database
 	UseDBForRetryQueue  bool
 	MaintenanceInterval time.Duration
 	topicNameGenerator  topicNameGenerator

--- a/config/config.go
+++ b/config/config.go
@@ -175,7 +175,7 @@ func (cfg *Config) addTopics(topics []*KafkaTopic) {
 }
 
 func (cfg *Config) loadFromEnvVars() error {
-	cfg.Host = strings.Split(os.Getenv(EnvVarHost), ",")
+	cfg.Host = envVarAsStringSlice(EnvVarHost)
 	cfg.Group = os.Getenv(EnvVarGroup)
 	cfg.TLSEnable = envVarAsBool(EnvVarTLSEnable)
 	cfg.TLSSkipVerifyPeer = envVarAsBool(EnvVarTLSSkipVerify)
@@ -187,7 +187,11 @@ func (cfg *Config) loadFromEnvVars() error {
 	cfg.DB.Port = envVarAsInt(EnvVarDbPort)
 	cfg.MaintenanceInterval = time.Second * time.Duration(envVarAsInt(EnvVarDbMaintenanceInterval))
 
-	sourceTopics := strings.Split(os.Getenv(EnvVarSourceTopics), ",")
+	sourceTopics := envVarAsStringSlice(EnvVarSourceTopics)
+	if len(sourceTopics) == 0 {
+		return fmt.Errorf("consumer/config: you must define a %s value", EnvVarSourceTopics)
+	}
+
 	retryIntervals, err := envVarAsIntSlice(EnvVarRetryIntervals)
 	if err != nil {
 		return fmt.Errorf("consumer/config: error parsing %s: %w", EnvVarRetryIntervals, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -454,7 +454,8 @@ func TestNewConfig(t *testing.T) {
 				"product":                       expMainProduct,
 				"deadLetter.kafkaGroup.product": expDeadLetterProduct,
 			},
-			DBRetries: DBRetries{"product": []*DBTopicRetry{}},
+			DBRetries:           DBRetries{"product": []*DBTopicRetry{}},
+			MaintenanceInterval: time.Hour * 1,
 		}
 
 		c, err := NewConfig()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -371,6 +371,7 @@ func TestNewConfig(t *testing.T) {
 	os.Setenv("DB_PASS", "pass123")
 	os.Setenv("DB_SCHEMA", "consumer")
 	os.Setenv("USE_DB_RETRY_QUEUE", "true")
+	os.Setenv("MAINTENANCE_INTERVAL_SECONDS", "100")
 	defer os.Clearenv()
 
 	expDeadLetterProduct := &KafkaTopic{
@@ -464,7 +465,8 @@ func TestNewConfig(t *testing.T) {
 			User:   "user",
 			Pass:   "pass123",
 		},
-		UseDBForRetryQueue: true,
+		UseDBForRetryQueue:  true,
+		MaintenanceInterval: time.Second * 100,
 	}
 
 	c, err := NewConfig()

--- a/config/helper.go
+++ b/config/helper.go
@@ -38,6 +38,15 @@ func envVarAsIntSlice(name string) ([]int, error) {
 	return i, nil
 }
 
+func envVarAsStringSlice(name string) []string {
+	envVal := os.Getenv(name)
+	if envVal == "" {
+		return []string{}
+	}
+
+	return strings.Split(envVal, ",")
+}
+
 func envVarAsInt(name string) int {
 	val, err := strconv.Atoi(strings.TrimSpace(os.Getenv(name)))
 	if err != nil {

--- a/config/helper_test.go
+++ b/config/helper_test.go
@@ -107,3 +107,24 @@ func TestEnvVarAsBool(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvVarAsStringSlice(t *testing.T) {
+	os.Setenv("FOO", "BAR,BAZ")
+	defer os.Clearenv()
+
+	t.Run("it returns string slice from env var", func(t *testing.T) {
+		exp := []string{"BAR", "BAZ"}
+
+		if diff := deep.Equal(exp, envVarAsStringSlice("FOO")); diff != nil {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("it returns empty slice when env var is empty", func(t *testing.T) {
+		exp := []string{}
+
+		if diff := deep.Equal(exp, envVarAsStringSlice("BUZZ")); diff != nil {
+			t.Error(diff)
+		}
+	})
+}

--- a/data/failure/model/failure.go
+++ b/data/failure/model/failure.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"encoding/base64"
 	"encoding/json"
 
 	"github.com/Shopify/sarama"
@@ -35,17 +34,10 @@ func FailureFromSaramaMessage(err error, nextTopic string, sm *sarama.ConsumerMe
 }
 
 func saramaRecordHeadersToJson(headers []*sarama.RecordHeader) []byte {
-	headerMap := map[string][]byte{}
+	headerMap := map[string]string{}
 
 	for _, h := range headers {
-		valueBytes, err := base64.StdEncoding.DecodeString(string(h.Value))
-		// we store the original h.Value if something went wrong, as this might give us the
-		// chance to inspect the data later as it is stored in retry record in the database
-		if err != nil {
-			headerMap[string(h.Key)] = h.Value
-		} else {
-			headerMap[string(h.Key)] = valueBytes
-		}
+		headerMap[string(h.Key)] = string(h.Value)
 	}
 
 	// we silence the error if the marshalling fails, as the data is likely not valid

--- a/data/migrations/20211108100457_retries_updated_at_index.down.sql
+++ b/data/migrations/20211108100457_retries_updated_at_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS retries_updated_at_idx;

--- a/data/migrations/20211108100457_retries_updated_at_index.up.sql
+++ b/data/migrations/20211108100457_retries_updated_at_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS retries_updated_at_idx ON kafka_consumer_retries (updated_at);

--- a/data/retry/internal/repository.go
+++ b/data/retry/internal/repository.go
@@ -49,6 +49,12 @@ func (r Repository) GetMessagesForRetry(ctx context.Context, topic string, seque
 	return r.getCreatedEventBatch(ctx, batchId)
 }
 
+func (r Repository) DeleteSuccessful(ctx context.Context, olderThan time.Time) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM kafka_consumer_retries WHERE successful = true AND updated_at <= $1;`, olderThan)
+
+	return err
+}
+
 func (r Repository) MarkRetrySuccessful(ctx context.Context, retry model.Retry) error {
 	q := `UPDATE kafka_consumer_retries
 		SET attempts = $1, last_error = '', retry_finished_at = NOW(), errored = false, successful = true, updated_at = NOW()

--- a/data/retry/manager.go
+++ b/data/retry/manager.go
@@ -52,7 +52,7 @@ func (m Manager) PublishFailure(ctx context.Context, failure failuremodel.Failur
 }
 
 func (m Manager) RunMaintenance(ctx context.Context) error {
-	olderThan := time.Now().Add(-1 * deleteSuccessfulRetriesAfter)
+	olderThan := time.Now().In(time.UTC).Add(-1 * deleteSuccessfulRetriesAfter)
 
 	return m.repo.DeleteSuccessful(ctx, olderThan)
 }

--- a/data/retry/manager_test.go
+++ b/data/retry/manager_test.go
@@ -198,6 +198,31 @@ func TestManager_PublishFailure(t *testing.T) {
 	})
 }
 
+func TestManager_RunMaintenance(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+
+	t.Run("runs maintenance", func(t *testing.T) {
+		manager, repo := newManagerForTests(false)
+
+		if err := manager.RunMaintenance(ctx); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+
+		if now.Sub(repo.receivedOlderThan) > time.Hour {
+			t.Error("repo.DeleteSuccessful() should have been called with olderThan time of 1 hour ago, but was not")
+		}
+	})
+
+	t.Run("returns error from repo", func(t *testing.T) {
+		manager, _ := newManagerForTests(true)
+
+		if err := manager.RunMaintenance(ctx); err == nil {
+			t.Error("expected an error but got nil")
+		}
+	})
+}
+
 func newManagerForTests(repoWillError bool) (Manager, *mockRepository) {
 	repo := newMockRepository(repoWillError)
 	manager := Manager{

--- a/data/retry/mock_repository_test.go
+++ b/data/retry/mock_repository_test.go
@@ -15,6 +15,7 @@ type mockRepository struct {
 	PublishedFailure      *failuremodel.Failure
 	retriesToReturn       []model.Retry
 	willError             bool
+	receivedOlderThan     time.Time
 }
 
 func newMockRepository(willError bool) *mockRepository {
@@ -49,5 +50,13 @@ func (m *mockRepository) PublishFailure(ctx context.Context, failure failuremode
 		return errors.New("oops")
 	}
 	m.PublishedFailure = &failure
+	return nil
+}
+
+func (m *mockRepository) DeleteSuccessful(ctx context.Context, olderThan time.Time) error {
+	if m.willError {
+		return errors.New("oops")
+	}
+	m.receivedOlderThan = olderThan
 	return nil
 }

--- a/integration/kafka_consumer_test.go
+++ b/integration/kafka_consumer_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-test/deep"
+
+	"github.com/inviqa/kafka-consumer-go/data/retry/model"
 	"github.com/inviqa/kafka-consumer-go/integration/kafka"
 )
 
@@ -58,14 +61,16 @@ func TestMessagesAreConsumedFromKafka_WithError(t *testing.T) {
 }
 
 func TestMessagesAreConsumedFromKafka_WithDbRetries(t *testing.T) {
-	publishTestMessageToKafka(kafka.TestMessage{})
+	publishTestMessageToKafka(kafka.TestMessage{
+		XEventId: "test-consume-db-retry",
+	})
 
 	handler := kafka.NewTestConsumerHandler()
 	handler.WillFail()
 
 	err := consumeFromKafkaUsingDbRetriesUntil(func(doneCh chan<- bool) {
 		for {
-			if len(handler.RecvdMessages) == 2 {
+			if len(handler.RecvdMessages) >= 2 {
 				doneCh <- true
 				return
 			}
@@ -76,67 +81,35 @@ func TestMessagesAreConsumedFromKafka_WithDbRetries(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
+	// we expect 2 messages to have been received, one for the original consume operation and
+	// another for retry which should have been picked up from the database retry table
 	if len(handler.RecvdMessages) != 2 {
-		t.Errorf("expected 2 messages to be received by handler, received %d", len(handler.RecvdMessages))
+		t.Fatalf("expected 2 messages to be received by handler, received %d", len(handler.RecvdMessages))
 	}
-}
 
-func TestRegularDbMaintenance(t *testing.T) {
-	defaultMaintenanceInterval := cfg.MaintenanceInterval
-	cfg.MaintenanceInterval = time.Millisecond * 100
-	defer func() {
-		cfg.MaintenanceInterval = defaultMaintenanceInterval
-	}()
+	got, err := dbRetryWithEventId("test-consume-db-retry")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	oneHourAgo := time.Now().In(time.UTC).Add(time.Hour * -1)
-	oneMinuteAgo := time.Now().In(time.UTC).Add(time.Minute * -1)
+	exp := &Retry{
+		Retry: model.Retry{
+			ID:             got.ID,
+			Topic:          "mainTopic",
+			PayloadJSON:    []byte(`{"type":"","data":{},"event_id":"test-consume-db-retry"}`),
+			PayloadHeaders: []byte(`{"foo":"bar"}`),
+			PayloadKey:     []byte(`message-key`),
+			KafkaOffset:    got.KafkaOffset,
+			KafkaPartition: 0,
+			Attempts:       2,
+			Deadlettered:   true,
+			Errored:        true,
+		},
+		Successful: false,
+		LastError:  "oops",
+	}
 
-	t.Run("it cleans up successfully processed retries updated over an hour ago", func(t *testing.T) {
-		purgeDatabase()
-		insertSuccessfullyProcessedDbRetry(oneHourAgo)
-		insertSuccessfullyProcessedDbRetry(oneMinuteAgo)
-
-		if got := retriesRecordCount(); got != 2 {
-			t.Fatalf("expected 2 fixture records to be added to retry table, but there was %d instead", got)
-		}
-
-		// given the maintenance job is part of the consumer collection, we just start that
-		// up as if under normal operation and wait until the job will have ran based on the
-		// configured maintenance interval
-		err := consumeFromKafkaUsingDbRetriesUntil(func(donech chan<- bool) {
-			time.Sleep(time.Millisecond * 120)
-			donech <- true
-		}, kafka.NewTestConsumerHandler().Handle)
-
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		if got := retriesRecordCount(); got != 1 {
-			t.Errorf("expected 1 retry record to remain, but got %d instead", got)
-		}
-	})
-
-	t.Run("it does not touch errored and deadlettered retries", func(t *testing.T) {
-		purgeDatabase()
-		insertErroredProcessedDbRetry(oneHourAgo)
-		insertDeadletteredProcessedDbRetry(oneHourAgo)
-
-		if got := retriesRecordCount(); got != 2 {
-			t.Fatalf("expected 2 fixture records to be added to retry table, but there was %d instead", got)
-		}
-
-		err := consumeFromKafkaUsingDbRetriesUntil(func(donech chan<- bool) {
-			time.Sleep(time.Millisecond * 120)
-			donech <- true
-		}, kafka.NewTestConsumerHandler().Handle)
-
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		if got := retriesRecordCount(); got != 2 {
-			t.Errorf("expected 2 retry records to remain, but got %d instead", got)
-		}
-	})
+	if diff := deep.Equal(exp, got); diff != nil {
+		t.Error(diff)
+	}
 }

--- a/integration/kafka_consumer_test.go
+++ b/integration/kafka_consumer_test.go
@@ -83,7 +83,7 @@ func TestMessagesAreConsumedFromKafka_WithDbRetries(t *testing.T) {
 
 func TestRegularDbMaintenance(t *testing.T) {
 	defaultMaintenanceInterval := cfg.MaintenanceInterval
-	cfg.MaintenanceInterval = time.Millisecond*100
+	cfg.MaintenanceInterval = time.Millisecond * 100
 	defer func() {
 		cfg.MaintenanceInterval = defaultMaintenanceInterval
 	}()
@@ -105,7 +105,7 @@ func TestRegularDbMaintenance(t *testing.T) {
 		// configured maintenance interval
 		err := consumeFromKafkaUsingDbRetriesUntil(func(donech chan<- bool) {
 			time.Sleep(time.Millisecond * 120)
-			donech<- true
+			donech <- true
 		}, kafka.NewTestConsumerHandler().Handle)
 
 		if err != nil {
@@ -128,7 +128,7 @@ func TestRegularDbMaintenance(t *testing.T) {
 
 		err := consumeFromKafkaUsingDbRetriesUntil(func(donech chan<- bool) {
 			time.Sleep(time.Millisecond * 120)
-			donech<- true
+			donech <- true
 		}, kafka.NewTestConsumerHandler().Handle)
 
 		if err != nil {

--- a/integration/kafka_consumer_test.go
+++ b/integration/kafka_consumer_test.go
@@ -80,3 +80,63 @@ func TestMessagesAreConsumedFromKafka_WithDbRetries(t *testing.T) {
 		t.Errorf("expected 2 messages to be received by handler, received %d", len(handler.RecvdMessages))
 	}
 }
+
+func TestRegularDbMaintenance(t *testing.T) {
+	defaultMaintenanceInterval := cfg.MaintenanceInterval
+	cfg.MaintenanceInterval = time.Millisecond*100
+	defer func() {
+		cfg.MaintenanceInterval = defaultMaintenanceInterval
+	}()
+
+	oneHourAgo := time.Now().In(time.UTC).Add(time.Hour * -1)
+	oneMinuteAgo := time.Now().In(time.UTC).Add(time.Minute * -1)
+
+	t.Run("it cleans up successfully processed retries updated over an hour ago", func(t *testing.T) {
+		purgeDatabase()
+		insertSuccessfullyProcessedDbRetry(oneHourAgo)
+		insertSuccessfullyProcessedDbRetry(oneMinuteAgo)
+
+		if got := retriesRecordCount(); got != 2 {
+			t.Fatalf("expected 2 fixture records to be added to retry table, but there was %d instead", got)
+		}
+
+		// given the maintenance job is part of the consumer collection, we just start that
+		// up as if under normal operation and wait until the job will have ran based on the
+		// configured maintenance interval
+		err := consumeFromKafkaUsingDbRetriesUntil(func(donech chan<- bool) {
+			time.Sleep(time.Millisecond * 120)
+			donech<- true
+		}, kafka.NewTestConsumerHandler().Handle)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if got := retriesRecordCount(); got != 1 {
+			t.Errorf("expected 1 retry record to remain, but got %d instead", got)
+		}
+	})
+
+	t.Run("it does not touch errored and deadlettered retries", func(t *testing.T) {
+		purgeDatabase()
+		insertErroredProcessedDbRetry(oneHourAgo)
+		insertDeadletteredProcessedDbRetry(oneHourAgo)
+
+		if got := retriesRecordCount(); got != 2 {
+			t.Fatalf("expected 2 fixture records to be added to retry table, but there was %d instead", got)
+		}
+
+		err := consumeFromKafkaUsingDbRetriesUntil(func(donech chan<- bool) {
+			time.Sleep(time.Millisecond * 120)
+			donech<- true
+		}, kafka.NewTestConsumerHandler().Handle)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if got := retriesRecordCount(); got != 2 {
+			t.Errorf("expected 2 retry records to remain, but got %d instead", got)
+		}
+	})
+}

--- a/integration/maintenance_test.go
+++ b/integration/maintenance_test.go
@@ -1,0 +1,70 @@
+// +build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/inviqa/kafka-consumer-go/integration/kafka"
+)
+
+func TestRegularDbMaintenance(t *testing.T) {
+	defaultMaintenanceInterval := cfg.MaintenanceInterval
+	cfg.MaintenanceInterval = time.Millisecond * 100
+	defer func() {
+		cfg.MaintenanceInterval = defaultMaintenanceInterval
+	}()
+
+	oneHourAgo := time.Now().In(time.UTC).Add(time.Hour * -1)
+	oneMinuteAgo := time.Now().In(time.UTC).Add(time.Minute * -1)
+
+	t.Run("it cleans up successfully processed retries updated over an hour ago", func(t *testing.T) {
+		purgeDatabase()
+		insertSuccessfullyProcessedDbRetry(oneHourAgo)
+		insertSuccessfullyProcessedDbRetry(oneMinuteAgo)
+
+		if got := retriesRecordCount(); got != 2 {
+			t.Fatalf("expected 2 fixture records to be added to retry table, but there was %d instead", got)
+		}
+
+		// given the maintenance job is part of the consumer collection, we just start that
+		// up as if under normal operation and wait until the job will have ran based on the
+		// configured maintenance interval
+		err := consumeFromKafkaUsingDbRetriesUntil(func(donech chan<- bool) {
+			time.Sleep(time.Millisecond * 120)
+			donech <- true
+		}, kafka.NewTestConsumerHandler().Handle)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if got := retriesRecordCount(); got != 1 {
+			t.Errorf("expected 1 retry record to remain, but got %d instead", got)
+		}
+	})
+
+	t.Run("it does not touch errored and deadlettered retries", func(t *testing.T) {
+		purgeDatabase()
+		insertErroredProcessedDbRetry(oneHourAgo)
+		insertDeadletteredProcessedDbRetry(oneHourAgo)
+
+		if got := retriesRecordCount(); got != 2 {
+			t.Fatalf("expected 2 fixture records to be added to retry table, but there was %d instead", got)
+		}
+
+		err := consumeFromKafkaUsingDbRetriesUntil(func(donech chan<- bool) {
+			time.Sleep(time.Millisecond * 120)
+			donech <- true
+		}, kafka.NewTestConsumerHandler().Handle)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if got := retriesRecordCount(); got != 2 {
+			t.Errorf("expected 2 retry records to remain, but got %d instead", got)
+		}
+	})
+}

--- a/integration/retry.go
+++ b/integration/retry.go
@@ -1,0 +1,11 @@
+package integration
+
+import (
+	"github.com/inviqa/kafka-consumer-go/data/retry/model"
+)
+
+type Retry struct {
+	model.Retry
+	Successful bool
+	LastError  string
+}

--- a/kafka_consumer_db_collection_test.go
+++ b/kafka_consumer_db_collection_test.go
@@ -31,15 +31,16 @@ func TestNewKafkaConsumerDbCollection(t *testing.T) {
 	logger := log.NullLogger{}
 
 	exp := &kafkaConsumerDbCollection{
-		kafkaConsumers: []sarama.ConsumerGroup{},
-		cfg:            cfg,
-		producer:       dp,
-		retryManager:   repo,
-		handler:        newConsumer(fch, cfg, hm, logger),
-		handlerMap:     hm,
-		saramaCfg:      scfg,
-		logger:         logger,
-		connectToKafka: defaultKafkaConnector,
+		kafkaConsumers:      []sarama.ConsumerGroup{},
+		cfg:                 cfg,
+		producer:            dp,
+		retryManager:        repo,
+		handler:             newConsumer(fch, cfg, hm, logger),
+		handlerMap:          hm,
+		saramaCfg:           scfg,
+		logger:              logger,
+		connectToKafka:      defaultKafkaConnector,
+		maintenanceInterval: defaultMaintenanceInterval,
 	}
 
 	got := newKafkaConsumerDbCollection(cfg, dp, repo, fch, hm, scfg, logger, defaultKafkaConnector)
@@ -51,13 +52,10 @@ func TestNewKafkaConsumerDbCollection(t *testing.T) {
 
 func TestKafkaConsumerDbCollection_Start(t *testing.T) {
 	defaultDbRetryPollInterval := dbRetryPollInterval
-	defaultMaintenanceInterval := maintenanceInterval
 	dbRetryPollInterval = time.Millisecond * 25
-	maintenanceInterval = time.Millisecond * 25
 
 	defer func() {
 		dbRetryPollInterval = defaultDbRetryPollInterval
-		maintenanceInterval = defaultMaintenanceInterval
 	}()
 
 	exampleMsg := &sarama.ConsumerMessage{
@@ -107,6 +105,8 @@ func TestKafkaConsumerDbCollection_Start(t *testing.T) {
 		col, repo := kafkaConsumerDbCollectionForTests(mcg, func(msg *sarama.ConsumerMessage) error {
 			return nil
 		}, false)
+
+		col.setMaintenanceInterval(time.Millisecond * 20)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
 		defer cancel()

--- a/kafka_consumer_db_collection_test.go
+++ b/kafka_consumer_db_collection_test.go
@@ -51,9 +51,13 @@ func TestNewKafkaConsumerDbCollection(t *testing.T) {
 
 func TestKafkaConsumerDbCollection_Start(t *testing.T) {
 	defaultDbRetryPollInterval := dbRetryPollInterval
+	defaultMaintenanceInterval := maintenanceInterval
 	dbRetryPollInterval = time.Millisecond * 25
+	maintenanceInterval = time.Millisecond * 25
+
 	defer func() {
 		dbRetryPollInterval = defaultDbRetryPollInterval
+		maintenanceInterval = defaultMaintenanceInterval
 	}()
 
 	exampleMsg := &sarama.ConsumerMessage{
@@ -114,6 +118,10 @@ func TestKafkaConsumerDbCollection_Start(t *testing.T) {
 
 		if got := repo.getPublishedFailureCountByTopic("product"); got != 0 {
 			t.Errorf("expected 0 failures to be produced in database, but got %d", got)
+		}
+
+		if got := repo.runMaintenanceCallCount; got != 2 {
+			t.Errorf("expected 2 calls to manager.RunMaintenance(), but got %d instead", got)
 		}
 	})
 

--- a/mock_retry_manager_test.go
+++ b/mock_retry_manager_test.go
@@ -16,6 +16,7 @@ type mockRetryManager struct {
 	willErrorOnGetBatch       bool
 	retryErrored              bool
 	retrySuccessful           bool
+	runMaintenanceCallCount   int
 }
 
 // GetBatch will return in-memory received failures as retries
@@ -59,6 +60,11 @@ func (mr *mockRetryManager) PublishFailure(ctx context.Context, f failuremodel.F
 		return errors.New("oops")
 	}
 	mr.recvdFailures[f.Topic] = append(mr.recvdFailures[f.Topic], f)
+	return nil
+}
+
+func (mr *mockRetryManager) RunMaintenance(ctx context.Context) error {
+	mr.runMaintenanceCallCount++
 	return nil
 }
 

--- a/tools/docs/configuration.md
+++ b/tools/docs/configuration.md
@@ -18,6 +18,7 @@ Configuration is initialised by calling `config.NewConfig()` in this module, whi
 | DB_USER               | No        | Database user.                                                                                                                                                                                              |
 | DB_PASS               | No        | Database password.                                                                                                                                                                                          |
 | DB_SCHEMA             | No        | Database name.                                                                                                                                                                                              |
+| MAINTENANCE_INTERVAL_SECONDS | No | How regularly the maintenance job will be run. Defaults to every hour. NOTE: You do not need to worry about this if you are not using [database retries](#database-retries). Even then, you should never need to change this value. 
 | TLS_ENABLE            | No        | Whether to enable TLS when communicating with Kafka and the database. We recommend enabling this if your database and Kafka cluster support it. **Defaults to false.**                                      |
 | TLS_SKIP_VERIFY_PEER  | No        | Whether to skip peer verification when connecting over TLS. **Defaults to false.**                                                                                                                          |
 

--- a/tools/docs/configuration.md
+++ b/tools/docs/configuration.md
@@ -45,7 +45,9 @@ You can see it has automatically generated the retry and deadLetter topic names 
 
 ### Database retries
 
-If you set `USE_DB_RETRY_QUEUE` to `true`, then messages needing a retry will be stored in a database table that is automatically created when the consumer starts. You will need to provide database credentials using the `DB_*` env vars detailed in the config table above.
+If you set `USE_DB_RETRY_QUEUE` to `true`, then messages needing a retry will be stored in a Postgres database table that is automatically created when the consumer starts. You will need to provide database credentials using the `DB_*` env vars detailed in the config table above.
+
+>_NOTE: We may add support for additional database engines in a future release._
 
 ### Flow of event processing:
 

--- a/vars.go
+++ b/vars.go
@@ -3,8 +3,8 @@ package consumer
 import "time"
 
 var (
-	maxConnectionAttempts = 10
-	connectionInterval    = time.Millisecond * 500
+	maxConnectionAttempts      = 10
+	connectionInterval         = time.Millisecond * 500
 	dbRetryPollInterval        = time.Second * 5
 	defaultMaintenanceInterval = time.Hour * 1
 	defaultKafkaConnector      = connectToKafka

--- a/vars.go
+++ b/vars.go
@@ -6,5 +6,6 @@ var (
 	maxConnectionAttempts = 10
 	connectionInterval    = time.Millisecond * 500
 	dbRetryPollInterval   = time.Second * 5
+	maintenanceInterval   = time.Hour * 1
 	defaultKafkaConnector = connectToKafka
 )

--- a/vars.go
+++ b/vars.go
@@ -5,7 +5,7 @@ import "time"
 var (
 	maxConnectionAttempts = 10
 	connectionInterval    = time.Millisecond * 500
-	dbRetryPollInterval   = time.Second * 5
-	maintenanceInterval   = time.Hour * 1
-	defaultKafkaConnector = connectToKafka
+	dbRetryPollInterval        = time.Second * 5
+	defaultMaintenanceInterval = time.Hour * 1
+	defaultKafkaConnector      = connectToKafka
 )


### PR DESCRIPTION
Adds a new goroutine to the consumer collection's Start() method that will periodically run a maintenance job on the retry manager. Right now, the maintenance job only cleans up any successfully processed retries, i.e. retries that have been successfully processed without error. Later, we may expand this job to include other tasks.

TODO:
- [x] write integration tests
- [x] improve integration test assertions for DB retries to give more confidence
- [x] add default value for `MAINTENANCE_INTERVAL_SECONDS` env var
- [x] add index for delete op


Completes #4 