### PR TITLE
Reduce number of goroutines and consumers for DB kafka collection

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -69,10 +69,10 @@ func (c *consumer) sendToFailureChannel(message *sarama.ConsumerMessage, err err
 	c.failureCh <- model.FailureFromSaramaMessage(err, nextTopic, message)
 }
 
-func (c *consumer) Setup(session sarama.ConsumerGroupSession) error {
+func (c *consumer) Setup(sarama.ConsumerGroupSession) error {
 	return nil
 }
 
-func (c *consumer) Cleanup(session sarama.ConsumerGroupSession) error {
+func (c *consumer) Cleanup(sarama.ConsumerGroupSession) error {
 	return nil
 }

--- a/consumer_runner.go
+++ b/consumer_runner.go
@@ -36,7 +36,7 @@ func Start(cfg *config.Config, ctx context.Context, hs HandlerMap, logger log.Lo
 		if err != nil {
 			return fmt.Errorf("could not start Kafka failure producer: %w", err)
 		}
-		cons = newKafkaConsumerCollection(cfg, kafkaProducer, fch, hs, srmCfg, logger)
+		cons = newKafkaConsumerCollection(cfg, kafkaProducer, fch, hs, srmCfg, logger, defaultKafkaConnector)
 	}
 
 	if err := cons.Start(ctx, wg); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/Shopify/sarama v1.30.0
-	github.com/go-test/deep v1.0.4
+	github.com/go-test/deep v1.0.8
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -388,6 +388,8 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
-github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=

--- a/kafka_connector.go
+++ b/kafka_connector.go
@@ -1,0 +1,10 @@
+package consumer
+
+import (
+	"github.com/Shopify/sarama"
+
+	"github.com/inviqa/kafka-consumer-go/config"
+	"github.com/inviqa/kafka-consumer-go/log"
+)
+
+type kafkaConnector func(cfg *config.Config, saramaCfg *sarama.Config, logger log.Logger) (sarama.ConsumerGroup, error)

--- a/kafka_consumer_collection_test.go
+++ b/kafka_consumer_collection_test.go
@@ -2,12 +2,13 @@ package consumer
 
 import (
 	"context"
-	"reflect"
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/go-test/deep"
 
 	"github.com/inviqa/kafka-consumer-go/config"
 	"github.com/inviqa/kafka-consumer-go/data/failure/model"
@@ -16,6 +17,11 @@ import (
 )
 
 func TestNewCollection(t *testing.T) {
+	deep.CompareUnexportedFields = true
+	defer func() {
+		deep.CompareUnexportedFields = false
+	}()
+
 	cfg := &config.Config{}
 	fp := newKafkaFailureProducer(saramatest.NewMockSyncProducer(), make(chan model.Failure, 10), nil)
 	fch := make(chan model.Failure)
@@ -24,75 +30,170 @@ func TestNewCollection(t *testing.T) {
 	hm := HandlerMap{}
 
 	exp := &kafkaConsumerCollection{
-		cfg:       cfg,
-		consumers: []sarama.ConsumerGroup{},
-		producer:  fp,
-		handler:   newConsumer(fch, cfg, hm, l),
-		saramaCfg: scfg,
-		logger:    l,
+		cfg:            cfg,
+		consumers:      []sarama.ConsumerGroup{},
+		producer:       fp,
+		handler:        newConsumer(fch, cfg, hm, l),
+		saramaCfg:      scfg,
+		logger:         l,
+		connectToKafka: defaultKafkaConnector,
 	}
-	col := newKafkaConsumerCollection(cfg, fp, fch, hm, scfg, nil)
-	if !reflect.DeepEqual(exp, col) {
-		t.Errorf("expected %v, but got %v", exp, col)
+	got := newKafkaConsumerCollection(cfg, fp, fch, hm, scfg, nil, defaultKafkaConnector)
+
+	if diff := deep.Equal(exp, got); diff != nil {
+		t.Error(diff)
 	}
 }
 
 func TestCollection_Close(t *testing.T) {
-	mcg1 := saramatest.NewMockConsumerGroup()
-	mcg2 := saramatest.NewMockConsumerGroup()
-	col := &kafkaConsumerCollection{consumers: []sarama.ConsumerGroup{mcg1, mcg2}}
+	t.Run("it closes consumers", func(t *testing.T) {
+		t.Parallel()
+		mcg1 := saramatest.NewMockConsumerGroup()
+		mcg2 := saramatest.NewMockConsumerGroup()
+		col := &kafkaConsumerCollection{consumers: []sarama.ConsumerGroup{mcg1, mcg2}}
 
-	col.Close()
+		col.Close()
 
-	if !mcg1.WasClosed() || !mcg2.WasClosed() {
-		t.Errorf("consumer collection was not closed properly")
-	}
-}
-
-func TestCollection_CloseWithError(t *testing.T) {
-	mcg1 := saramatest.NewMockConsumerGroup()
-	mcg2 := saramatest.NewMockConsumerGroup()
-	mcg1.ErrorOnClose()
-
-	col := &kafkaConsumerCollection{consumers: []sarama.ConsumerGroup{mcg1, mcg2}, logger: log.NullLogger{}}
-	col.Close()
-
-	if !mcg2.WasClosed() || len(col.consumers) > 0 {
-		t.Errorf("consumer collection was not closed properly")
-	}
-}
-
-func TestCollection_startConsumer(t *testing.T) {
-	mcg := saramatest.NewMockConsumerGroup()
-	ctx := context.Background()
-	cfg := &config.Config{}
-
-	col := &kafkaConsumerCollection{consumers: []sarama.ConsumerGroup{mcg}, cfg: cfg}
-
-	col.startConsumer(mcg, ctx, &sync.WaitGroup{}, &config.KafkaTopic{
-		Name:  "retry",
-		Delay: time.Millisecond * 1,
+		if !mcg1.WasClosed() || !mcg2.WasClosed() {
+			t.Errorf("consumer collection was not closed properly")
+		}
 	})
 
-	<-time.After(time.Millisecond * 5)
+	t.Run("it handles errors from closing consumers", func(t *testing.T) {
+		t.Parallel()
+		mcg1 := saramatest.NewMockConsumerGroup()
+		mcg2 := saramatest.NewMockConsumerGroup()
+		mcg1.ErrorOnClose()
 
-	if c := mcg.GetTopicConsumeCount("retry"); c == 0 {
-		t.Error("expected topic 'retry' to be consumed, but was not")
-	}
+		col := &kafkaConsumerCollection{consumers: []sarama.ConsumerGroup{mcg1, mcg2}, logger: log.NullLogger{}}
+		col.Close()
+
+		if !mcg2.WasClosed() || len(col.consumers) > 0 {
+			t.Errorf("consumer collection was not closed properly")
+		}
+	})
 }
 
-func TestCollection_startConsumerWithError(t *testing.T) {
-	mcg := saramatest.NewMockConsumerGroup()
-	mcg.ErrorOnConsume()
-	ctx, cancel := context.WithCancel(context.Background())
-	cfg := &config.Config{}
+func TestCollection_Start(t *testing.T) {
+	exampleMsg := &sarama.ConsumerMessage{
+		Topic: "product",
+		Value: []byte(`{"foo":"bar"}`),
+	}
 
-	col := &kafkaConsumerCollection{consumers: []sarama.ConsumerGroup{mcg}, cfg: cfg}
-
-	col.startConsumer(mcg, ctx, &sync.WaitGroup{}, &config.KafkaTopic{
-		Name:  "retry",
-		Delay: time.Millisecond * 1,
+	t.Run("errors when there are no main topics", func(t *testing.T) {
+		t.Parallel()
+		col := kafkaConsumerCollection{cfg: &config.Config{}}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*1)
+		defer cancel()
+		var wg sync.WaitGroup
+		if err := col.Start(ctx, &wg); err == nil {
+			t.Error("expected an error but got nil")
+		}
+		wg.Wait()
 	})
 
-	cancel()
+	t.Run("errors when it cannot connect to kafka", func(t *testing.T) {
+		t.Parallel()
+		col, _ := testKafkaConsumerCollection(saramatest.NewMockConsumerGroup(), nil, true)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*1)
+		defer cancel()
+		var wg sync.WaitGroup
+		if err := col.Start(ctx, &wg); err == nil {
+			t.Error("expected an error but got nil")
+		}
+		wg.Wait()
+	})
+
+	t.Run("handles errors on kafka consume", func(t *testing.T) {
+		t.Parallel()
+		mcg := saramatest.NewMockConsumerGroup()
+		mcg.ErrorOnConsume()
+		col, _ := testKafkaConsumerCollection(mcg, nil, false)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+		defer cancel()
+		var wg sync.WaitGroup
+		// errors from consume should be logged, but not returned
+		if err := col.Start(ctx, &wg); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		wg.Wait()
+
+		if !mcg.Consumed() {
+			t.Error("expected something to have been consumed, but was not")
+		}
+	})
+
+	t.Run("successful messages are not retried", func(t *testing.T) {
+		t.Parallel()
+		mcg := saramatest.NewMockConsumerGroup()
+		mcg.AddMessage(exampleMsg)
+		col, failureProd := testKafkaConsumerCollection(mcg, func(msg *sarama.ConsumerMessage) error {
+			return nil
+		}, false)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+		defer cancel()
+
+		var wg sync.WaitGroup
+		if err := col.Start(ctx, &wg); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		wg.Wait()
+
+		if got := failureProd.lastReceivedFailure(); got != nil {
+			t.Errorf("did not expect a failure, but got %#v", got)
+		}
+
+		if c := mcg.GetTopicConsumeCount("product"); c == 0 {
+			t.Error("expected topic 'product' to be consumed, but was not")
+		}
+	})
+
+	t.Run("failing messages are sent for retry", func(t *testing.T) {
+		t.Parallel()
+		mcg := saramatest.NewMockConsumerGroup()
+		mcg.AddMessage(exampleMsg)
+		var called bool
+		col, failureProd := testKafkaConsumerCollection(mcg, func(msg *sarama.ConsumerMessage) error {
+			if !called {
+				called = true
+				return errors.New("something bad happened")
+			}
+			return nil
+		}, false)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		if err := col.Start(ctx, &sync.WaitGroup{}); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+
+	L:
+		for {
+			select {
+			case <-time.After(time.Second * 1):
+				t.Error("did not receive any failures in time")
+			default:
+				if failureProd.numberOfReceivedFailures() == 1 {
+					cancel()
+					break L
+				}
+			}
+		}
+
+		if got := failureProd.numberOfReceivedFailures(); got != 1 {
+			t.Errorf("expected only 1 failure to be produced, but got %d", got)
+		}
+	})
+}
+
+func testKafkaConsumerCollection(mcg *saramatest.MockConsumerGroup, msgHandler Handler, errorOnConnect bool) (*kafkaConsumerCollection, *mockFailureProducer) {
+	fch := make(chan model.Failure, 10)
+
+	hm := HandlerMap{"product": msgHandler}
+	connector := testKafkaConnector{consumerGroup: mcg, willError: errorOnConnect}
+
+	mockFp := newMockFailureProducer(fch)
+
+	return newKafkaConsumerCollection(newTestConfig(), mockFp, fch, hm, sarama.NewConfig(), log.NullLogger{}, connector.connectToKafka), mockFp
 }

--- a/mock_failure_producer_test.go
+++ b/mock_failure_producer_test.go
@@ -1,0 +1,47 @@
+package consumer
+
+import (
+	"context"
+	"sync"
+
+	"github.com/inviqa/kafka-consumer-go/data/failure/model"
+)
+
+type mockFailureProducer struct {
+	sync.Mutex
+	fch               chan model.Failure
+	lastFailure       *model.Failure
+	failureRecvdCount int
+}
+
+func newMockFailureProducer(fch chan model.Failure) *mockFailureProducer {
+	return &mockFailureProducer{
+		fch: fch,
+	}
+}
+
+func (m *mockFailureProducer) listenForFailures(ctx context.Context, wg *sync.WaitGroup) {
+	go func() {
+		for {
+			select {
+			case failure := <-m.fch:
+				m.Lock()
+				m.failureRecvdCount++
+				m.lastFailure = &failure
+				m.Unlock()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (m *mockFailureProducer) lastReceivedFailure() *model.Failure {
+	m.Lock()
+	defer m.Unlock()
+	return m.lastFailure
+}
+
+func (m *mockFailureProducer) numberOfReceivedFailures() int {
+	return m.failureRecvdCount
+}

--- a/test/saramatest/sarama_consumer_group.go
+++ b/test/saramatest/sarama_consumer_group.go
@@ -105,6 +105,10 @@ func (mg *MockConsumerGroup) ErrorOnConsume() {
 	mg.errorOnConsume = true
 }
 
+func (mg *MockConsumerGroup) Consumed() bool {
+	return mg.consumed
+}
+
 func (mg *MockConsumerGroup) AddMessage(msg *sarama.ConsumerMessage) {
 	mg.msgsToConsume[msg.Topic] = append(mg.msgsToConsume[msg.Topic], msg)
 }


### PR DESCRIPTION
In the DB-retry based Kafka consumer collection, we now only spawn 1 main topic consumer for all topics rather than 1 separate consumer + goroutine per topic.

Additionally, this improves unit test coverage for the regular Kafka consumer collection as well, which was pretty poor before.