### PR TITLE
Update samara ErrOutOfBrokers check to cope with wrapping

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -30,7 +30,7 @@ func connectToKafka(cfg *config.Config, saramaCfg *sarama.Config, logger log.Log
 
 		// the cluster may be temporarily unreachable so if we see ErrOutOfBrokers we continue to the
 		// next iteration to make another attempt to connect
-		if err != sarama.ErrOutOfBrokers {
+		if !errors.Is(err, sarama.ErrOutOfBrokers) {
 			return nil, fmt.Errorf("error occurred creating Kafka consumer group client: %w", err)
 		}
 

--- a/kafka_producer.go
+++ b/kafka_producer.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -38,7 +39,7 @@ func newKafkaFailureProducerWithDefaults(cfg *config.Config, fch <-chan model.Fa
 		// the cluster may be temporarily unreachable so if we see ErrOutOfBrokers we continue to the
 		// next iteration to make another attempt to connect (the sarama.NewSyncProducer also internally
 		// makes retry attempts so we should connect within 3 attempts here (see maxConnectionAttempts)
-		if err != sarama.ErrOutOfBrokers {
+		if !errors.Is(err, sarama.ErrOutOfBrokers) {
 			return nil, fmt.Errorf("error occurred creating Kafka producer for retries: %w", err)
 		}
 


### PR DESCRIPTION
Samara 1.33.0 introduced the root cause to the error via error wrapping