### PR TITLE
handling more than 1 retries

### DIFF
--- a/config/db_retries.go
+++ b/config/db_retries.go
@@ -25,7 +25,7 @@ func (dr DBRetries) MakeRetryErrored(retry model.Retry) model.Retry {
 	retry.Errored = true
 	retry.Attempts = retry.Attempts + 1
 
-	if retry.Attempts >= dr.maxAttemptsForTopic(retry.Topic) {
+	if retry.Attempts > dr.maxAttemptsForTopic(retry.Topic) {
 		retry.Deadlettered = true
 	}
 

--- a/config/db_retries_test.go
+++ b/config/db_retries_test.go
@@ -38,10 +38,10 @@ func TestDBRetries_MakeRetryErrored(t *testing.T) {
 	})
 
 	t.Run("it marks retry as dead-lettered", func(t *testing.T) {
-		retry := model.Retry{Topic: "foo", Attempts: 1}
+		retry := model.Retry{Topic: "foo", Attempts: 2}
 		exp := model.Retry{
 			Topic:        "foo",
-			Attempts:     2,
+			Attempts:     3,
 			Errored:      true,
 			Deadlettered: true,
 		}

--- a/data/retry/internal/repository.go
+++ b/data/retry/internal/repository.go
@@ -91,7 +91,7 @@ func (r Repository) createEventBatch(ctx context.Context, topic string, sequence
 			SELECT id FROM kafka_consumer_retries
 			WHERE topic = $2
 			AND (
-				(batch_id IS NULL AND retry_started_at IS NULL) OR 
+				batch_id IS NULL OR
 				(batch_id IS NOT NULL AND retry_finished_at IS NULL AND retry_started_at < $3)
 			)
 			AND attempts = $4 AND deadlettered = false AND successful = false AND updated_at <= $5

--- a/data/retry/manager_test.go
+++ b/data/retry/manager_test.go
@@ -141,7 +141,7 @@ func TestManager_MarkErrored(t *testing.T) {
 		retry := model.Retry{
 			ID:       123,
 			Topic:    "foo",
-			Attempts: 1,
+			Attempts: 2,
 		}
 		err := manager.MarkErrored(ctx, retry, errors.New("foo"))
 		if err != nil {
@@ -153,7 +153,7 @@ func TestManager_MarkErrored(t *testing.T) {
 			Topic:        "foo",
 			Errored:      true,
 			Deadlettered: true,
-			Attempts:     2,
+			Attempts:     3,
 		}
 
 		if diff := deep.Equal(&expRetry, repo.RetryMarkedErrored); diff != nil {

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -68,7 +68,7 @@ func createConfig() *config.Config {
 		SetKafkaHost([]string{"localhost:9092"}).
 		SetKafkaGroup("test").
 		SetSourceTopics([]string{"mainTopic"}).
-		SetRetryIntervals([]int{1}).
+		SetRetryIntervals([]int{1, 2}).
 		SetDBHost("127.0.0.1").
 		SetDBPass("kafka-consumer").
 		SetDBUser("kafka-consumer").
@@ -122,7 +122,7 @@ func consumeFromKafkaUsingDbRetriesUntil(done func(chan<- bool), handler consume
 		cfg.UseDBForRetryQueue = false
 	}()
 
-	return test.ConsumeFromKafkaUntil(cfg, consumer.HandlerMap{"mainTopic": handler}, time.Second*10, done)
+	return test.ConsumeFromKafkaUntil(cfg, consumer.HandlerMap{"mainTopic": handler}, time.Second*20, done)
 }
 
 func dbRetryWithEventId(eventId string) (*Retry, error) {


### PR DESCRIPTION
`MakeRetryErrored` marked the retry as deadlettered too early, which resulted in that the last retry was not even executed.

`createEventBatch` queried only those retry rows which were stale or have never been retried before. The issue was that `MarkRetryErrored` in the repository have reset the batch id, but kept the retry started at date not null, those the next batch missed to include the retry.